### PR TITLE
Created capability for users other than only administrators to send email.

### DIFF
--- a/includes/class-send-users-email-activator.php
+++ b/includes/class-send-users-email-activator.php
@@ -7,6 +7,12 @@ class Send_Users_Email_Activator {
 
 	public static function activate() {
 		update_option( 'sue_send_users_email', [] );
+		// need a variable to access so we can call a method in the send_users_email_admin class			
+		$plugin = new Send_Users_Email();
+		$plugin_admin = new Send_Users_Email_Admin( $plugin->get_plugin_name(), $plugin->get_version() );
+
+		// tell the plugin admin class to do the activate actions
+		$plugin_admin->send_users_email_activate_admin_actions();
 	}
 
 }

--- a/includes/class-send-users-email-deactivator.php
+++ b/includes/class-send-users-email-deactivator.php
@@ -6,7 +6,12 @@
 class Send_Users_Email_Deactivator {
 
 	public static function deactivate() {
+	    // need a variable to access so we can call a method in the send_users_email_admin class			
+		$plugin = new Send_Users_Email();
+		$plugin_admin = new Send_Users_Email_Admin( $plugin->get_plugin_name(), $plugin->get_version() );
 
+		// tell the plugin admin class to do the deactivate actions
+		$plugin_admin->send_users_email_deactivate_admin_actions();
 	}
 
 }


### PR DESCRIPTION
Upon activation of the plugin, creates a new role called "Email Sender" which allows specific users to send email without needing to be administrators. Also assigns the capability of "email_sender" to the administrator role.
Upon deactivation of the plugin, deletes the new role called "Email Sender" and removes the capability of "email_sender" from the administrator role.